### PR TITLE
vfio/pci: Fix VFIOGroup use after free

### DIFF
--- a/hw/vfio/pci.c
+++ b/hw/vfio/pci.c
@@ -3712,6 +3712,7 @@ static void vfio_user_instance_finalize(Object *obj)
 
     if (group != NULL) {
         vfio_disconnect_proxy(group);
+        QLIST_REMOVE(group, next);
         g_free(group);
         vbasedev->group = NULL;
     }


### PR DESCRIPTION
The sanitizer reports:

==2534591==ERROR: AddressSanitizer: heap-use-after-free on address 0x60600007f600 at pc 0x557ca6aede56 bp 0x7ffd98571600 sp 0x7ffd985715e0 WRITE of size 8 at 0x60600007f600 thread T0
    #0 0x557ca6aede55 in vfio_connect_proxy /home/ctyun/workspace/code/qemu-5.0/hw/vfio/common.c:1936
    #1 0x557ca6b32d74 in vfio_user_pci_realize /home/ctyun/workspace/code/qemu-5.0/hw/vfio/pci.c:3649
    #2 0x557ca733c425 in pci_qdev_realize hw/pci/pci.c:2098
    #3 0x557ca7036370 in device_set_realized hw/core/qdev.c:891
    #4 0x557ca7709f27 in property_set_bool qom/object.c:2238
    #5 0x557ca771a01e in object_property_set_qobject qom/qom-qobject.c:26
    #6 0x557ca77120b8 in object_property_set_bool qom/object.c:1390
    #7 0x557ca6f2362e in qdev_device_add /home/ctyun/workspace/code/qemu-5.0/qdev-monitor.c:680
    #8 0x557ca6f2419f in qmp_device_add /home/ctyun/workspace/code/qemu-5.0/qdev-monitor.c:805
    #9 0x557ca6f24a78 in hmp_device_add /home/ctyun/workspace/code/qemu-5.0/qdev-monitor.c:905
    #10 0x557ca7572cdd in handle_hmp_command monitor/hmp.c:1082
    #11 0x557ca757323b in monitor_command_cb monitor/hmp.c:47
    #12 0x557ca7b0bfc2 in readline_handle_byte util/readline.c:408
    #13 0x557ca7573337 in monitor_read monitor/hmp.c:1312
    #14 0x557ca7927bee in mux_chr_read chardev/char-mux.c:228
    #15 0x557ca7920942 in fd_chr_read chardev/char-fd.c:68
    #16 0x7f3f7fa8e183 in g_main_context_dispatch (/usr/lib64/libglib-2.0.so.0+0x51183)
    #17 0x557ca7aa7caf in glib_pollfds_poll util/main-loop.c:219
    #18 0x557ca7aa7caf in os_host_main_loop_wait util/main-loop.c:242
    #19 0x557ca7aa7caf in main_loop_wait util/main-loop.c:518
    #20 0x557ca6c7e413 in qemu_main_loop /home/ctyun/workspace/code/qemu-5.0/softmmu/vl.c:1710
    #21 0x557ca67570fd in main /home/ctyun/workspace/code/qemu-5.0/softmmu/main.c:49
    #22 0x7f3f7e256b16 in __libc_start_main (/usr/lib64/libc.so.6+0x25b16)
    #23 0x557ca675a309 in _start (/root/sibs/qemu-system-x86_64+0x18d7309)

0x60600007f600 is located 32 bytes inside of 64-byte region [0x60600007f5e0,0x60600007f620) freed by thread T1 here:
    #0 0x7f3f7ff16c89 in free (/usr/lib64/libasan.so.4+0x151c89)
    #1 0x7f3f7fa93fa8 in g_free (/usr/lib64/libglib-2.0.so.0+0x56fa8)
    #2 0x557ca770f3bf in object_deinit qom/object.c:654
    #3 0x557ca770f3bf in object_finalize qom/object.c:668
    #4 0x557ca770f3bf in object_unref qom/object.c:1128
    #5 0x557ca7e669cf  (/root/sibs/qemu-system-x86_64+0x2fe39cf)

previously allocated by thread T0 here:
    #0 0x7f3f7ff1735b in calloc (/usr/lib64/libasan.so.4+0x15235b)
    #1 0x7f3f7fa93f00 in g_malloc0 (/usr/lib64/libglib-2.0.so.0+0x56f00)
    #2 0x557ca733c425 in pci_qdev_realize hw/pci/pci.c:2098

Thread T1 created by T0 here:
    #0 0x7f3f7ff096ac in __interceptor_pthread_create (/usr/lib64/libasan.so.4+0x1446ac)
    #1 0x557ca7abaf2f in qemu_thread_create util/qemu-thread-posix.c:556

SUMMARY: AddressSanitizer: heap-use-after-free /home/ctyun/workspace/code/qemu-5.0/hw/vfio/common.c:1936 in vfio_connect_proxy